### PR TITLE
feat(cli): add command-line arguments for mode, source, and parameter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ You can add OctoType as a Flake:
 
 ## 🔖 Arguments
 
-| Short       | Long               | Description                                    |
-| ----------- | ------------------ | ---------------------------------------------- |
-|             | `--print-config`   | Prints the current settings, modes, and source |
-| `-p`        | `--print-settings` | Prints the current settings                    |
-| `-c <path>` | `--config <path>`  | Overrides the default config location          |
-| `-h`        | `--help`           | Shows a help page with the list of arguments   |
+| Short               | Long                 | Description                                                  |
+| ------------------- | -------------------- | ------------------------------------------------------------ |
+|                     | `--print-config`     | Prints the current settings, modes, and source               |
+| `-p`                | `--print-settings`   | Prints the current settings                                  |
+| `-c <path>`         | `--config <path>`    | Overrides the default config location                        |
+| `-m <name>`         | `--mode <name>`      | Specifies a mode to run (starts at source selection)         |
+| `-s <name>`         | `--source <name>`    | Specifies a source to run (starts session directly)          |
+| `-P <name:val>`     | `--param <name:val>` | Specifies parameter overrides for session in `key:val` format|
+| `-h`                | `--help`             | Shows a help page with the list of arguments                 |
 
 ## ⚙️ Configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,7 +39,8 @@ impl App {
             page::Error::new(NO_CONFIG_ERROR.to_string()).into()
         } else if let Some(mode_name) = args.mode {
             if let Some(source_name) = args.source {
-                page::menu::create_cli_session(&config, &mode_name, &source_name, &args.params)?.into()
+                page::menu::create_cli_session(&config, &mode_name, &source_name, &args.params)?
+                    .into()
             } else {
                 page::Menu::new_with_mode(&config, &mode_name)?.into()
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
 use ratatui::{Frame, style::Stylize, text::ToLine, widgets::Padding};
 
+use crate::AppArgs;
 use crate::config::Config;
 use crate::page;
 use crate::utils::ROUNDED_BLOCK;
@@ -33,16 +34,23 @@ pub struct App {
 
 impl App {
     /// Creates a new `App`
-    pub fn new(config: Config) -> Self {
-        let page = if config.sources.is_empty() || config.modes.is_empty() {
+    pub fn new(config: Config, args: AppArgs) -> Result<Self, page::menu::ContextError> {
+        let page: page::Page = if config.sources.is_empty() || config.modes.is_empty() {
             page::Error::new(NO_CONFIG_ERROR.to_string()).into()
+        } else if let Some(mode_name) = args.mode {
+            if let Some(source_name) = args.source {
+                page::menu::create_cli_session(&config, &mode_name, &source_name, &args.params)?.into()
+            } else {
+                page::Menu::new_with_mode(&config, &mode_name)?.into()
+            }
         } else {
             page::Loading::load(&config, "Loading menu", |config| {
                 page::Menu::new(config).map(|menu| Message::Show(menu.into()))
             })
             .into()
         };
-        Self { page, config }
+
+        Ok(Self { page, config })
     }
 
     /// Runs the app

--- a/src/config/parameters.rs
+++ b/src/config/parameters.rs
@@ -187,7 +187,9 @@ impl Parameter {
         }
 
         match &mut self.definition {
-            Definition::Range { min, max, value, .. } => {
+            Definition::Range {
+                min, max, value, ..
+            } => {
                 let parsed: i64 = value_str.parse().map_err(|_| ParameterError::ParseValue {
                     name: name.to_string(),
                     value: value_str.to_string(),
@@ -427,9 +429,7 @@ mod tests {
             default: Some("easy".to_string()),
             selected: 0,
         };
-        let mut param = def
-            .into_parameter(true)
-            .expect("valid selection parameter");
+        let mut param = def.into_parameter(true).expect("valid selection parameter");
         assert_eq!(param.get_value(), "easy");
 
         param

--- a/src/config/parameters.rs
+++ b/src/config/parameters.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 pub type ParameterDefinitions = HashMap<String, Definition>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum ParameterError {
     #[error("Invalid range: {min} > {max}")]
     InvalidRange { min: i64, max: i64 },
@@ -24,6 +24,34 @@ pub enum ParameterError {
 
     #[error("Default doesn't exist in selection")]
     DefaultNonExistant,
+
+    #[error("Failed to parse value '{value}' for parameter '{name}': {reason}")]
+    ParseValue {
+        name: String,
+        value: String,
+        reason: String,
+    },
+
+    #[error("Value {value} out of bounds [{min}, {max}] for parameter '{name}'")]
+    OutOfBounds {
+        name: String,
+        value: i64,
+        min: i64,
+        max: i64,
+    },
+
+    #[error("Invalid selection '{value}' for parameter '{name}'. Valid options: {valid}")]
+    InvalidSelection {
+        name: String,
+        value: String,
+        valid: String,
+    },
+
+    #[error("Parameter '{0}' is fixed and cannot be changed")]
+    FixedParameter(String),
+
+    #[error("Unknown parameter '{0}'")]
+    UnknownParameter(String),
 }
 
 pub struct ParameterValues(HashMap<String, Parameter>);
@@ -147,6 +175,71 @@ impl Parameter {
             Definition::Toggle(b) => *b = !*b,
             _ => unreachable!("Tried to modify a non-mutable definition"),
         }
+    }
+
+    pub fn set_value_from_str(
+        &mut self,
+        name: &str,
+        value_str: &str,
+    ) -> Result<(), ParameterError> {
+        if !self.is_mutable() {
+            return Err(ParameterError::FixedParameter(name.to_string()));
+        }
+
+        match &mut self.definition {
+            Definition::Range { min, max, value, .. } => {
+                let parsed: i64 = value_str.parse().map_err(|_| ParameterError::ParseValue {
+                    name: name.to_string(),
+                    value: value_str.to_string(),
+                    reason: "expected an integer".to_string(),
+                })?;
+
+                if parsed < *min || parsed > *max {
+                    return Err(ParameterError::OutOfBounds {
+                        name: name.to_string(),
+                        value: parsed,
+                        min: *min,
+                        max: *max,
+                    });
+                }
+
+                *value = parsed;
+            }
+            Definition::Selection {
+                options, selected, ..
+            } => {
+                let pos = options
+                    .iter()
+                    .position(|opt| opt == value_str || opt.eq_ignore_ascii_case(value_str))
+                    .ok_or_else(|| ParameterError::InvalidSelection {
+                        name: name.to_string(),
+                        value: value_str.to_string(),
+                        valid: options.join(", "),
+                    })?;
+
+                *selected = pos;
+            }
+            Definition::Toggle(b) => {
+                let parsed: bool = match value_str.to_lowercase().as_str() {
+                    "true" | "1" | "yes" | "y" | "on" => true,
+                    "false" | "0" | "no" | "n" | "off" => false,
+                    _ => {
+                        return Err(ParameterError::ParseValue {
+                            name: name.to_string(),
+                            value: value_str.to_string(),
+                            reason: "expected a boolean (true/false)".to_string(),
+                        });
+                    }
+                };
+
+                *b = parsed;
+            }
+            Definition::FixedNumber(_) | Definition::FixedString(_) => {
+                return Err(ParameterError::FixedParameter(name.to_string()));
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -278,4 +371,105 @@ pub const fn default_range_step() -> i64 {
 
 pub const fn default_range_max() -> i64 {
     i64::MAX
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_range_value() {
+        let def = Definition::Range {
+            min: 10,
+            max: 100,
+            step: 5,
+            default: Some(20),
+            value: 20,
+        };
+        let mut param = def.into_parameter(true).expect("valid range parameter");
+        assert_eq!(param.get_value(), "20");
+
+        param
+            .set_value_from_str("words", "50")
+            .expect("valid value");
+        assert_eq!(param.get_value(), "50");
+
+        let err = param
+            .set_value_from_str("words", "5")
+            .expect_err("out of bounds");
+        assert_eq!(
+            err,
+            ParameterError::OutOfBounds {
+                name: "words".to_string(),
+                value: 5,
+                min: 10,
+                max: 100
+            }
+        );
+
+        let err = param
+            .set_value_from_str("words", "abc")
+            .expect_err("invalid int");
+        assert_eq!(
+            err,
+            ParameterError::ParseValue {
+                name: "words".to_string(),
+                value: "abc".to_string(),
+                reason: "expected an integer".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_set_selection_value() {
+        let def = Definition::Selection {
+            options: vec!["easy".to_string(), "medium".to_string(), "hard".to_string()],
+            default: Some("easy".to_string()),
+            selected: 0,
+        };
+        let mut param = def
+            .into_parameter(true)
+            .expect("valid selection parameter");
+        assert_eq!(param.get_value(), "easy");
+
+        param
+            .set_value_from_str("diff", "HARD")
+            .expect("valid selection");
+        assert_eq!(param.get_value(), "hard");
+
+        let err = param
+            .set_value_from_str("diff", "extreme")
+            .expect_err("invalid selection");
+        assert_eq!(
+            err,
+            ParameterError::InvalidSelection {
+                name: "diff".to_string(),
+                value: "extreme".to_string(),
+                valid: "easy, medium, hard".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_set_toggle_value() {
+        let def = Definition::Toggle(false);
+        let mut param = def.into_parameter(true).expect("valid toggle parameter");
+        assert_eq!(param.get_value(), "false");
+
+        param
+            .set_value_from_str("toggle", "yes")
+            .expect("valid toggle");
+        assert_eq!(param.get_value(), "true");
+    }
+
+    #[test]
+    fn test_set_fixed_value() {
+        let def = Definition::FixedString("fixed".to_string());
+        let mut param = def.into_parameter(false).expect("valid fixed parameter");
+
+        let err = param
+            .set_value_from_str("param", "val")
+            .expect_err("fixed param");
+        assert_eq!(err, ParameterError::FixedParameter("param".to_string()));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,26 +12,47 @@ use clap::Parser;
 use crate::config::Config;
 
 /// Cli-Arguments
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
-struct AppArgs {
+pub struct AppArgs {
     /// Prints the loaded config (Settings, Modes, Sources)
     #[arg(long)]
-    print_config: bool,
+    pub print_config: bool,
 
     /// Prints the loaded settings
     #[arg(short, long)]
-    print_settings: bool,
+    pub print_settings: bool,
 
     /// Specifies a config location
     #[arg(short, long)]
-    config: Option<String>,
+    pub config: Option<String>,
+
+    /// Specifies a mode to run
+    #[arg(short, long)]
+    pub mode: Option<String>,
+
+    /// Specifies a source to run
+    #[arg(short, long, requires = "mode")]
+    pub source: Option<String>,
+
+    /// Specifies a parameter in the format 'name:value'
+    #[arg(
+        short = 'P',
+        long = "param",
+        value_name = "PARAM:VALUE",
+        requires = "source"
+    )]
+    pub params: Vec<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = AppArgs::parse();
 
-    let override_path = args.config.map(|dir| PathBuf::from_str(&dir)).transpose()?;
+    let override_path = args
+        .config
+        .as_ref()
+        .map(|dir| PathBuf::from_str(dir))
+        .transpose()?;
 
     let config = Config::get(override_path)?;
 
@@ -45,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    App::new(config).run()?;
+    App::new(config, args)?.run()?;
 
     Ok(())
 }

--- a/src/page/menu.rs
+++ b/src/page/menu.rs
@@ -30,10 +30,7 @@ pub enum ContextError {
     NoModes,
 
     #[error("Mode '{name}' not found. Available modes: {available}")]
-    ModeNotFound {
-        name: String,
-        available: String,
-    },
+    ModeNotFound { name: String, available: String },
 
     #[error("Source '{name}' not found for mode '{mode}'. Available sources: {available}")]
     SourceNotFound {
@@ -163,7 +160,7 @@ pub struct SessionBuilder<'a> {
 }
 
 impl<'a> SessionBuilder<'a> {
-    pub fn new(config: &'a Config) -> Self {
+    pub const fn new(config: &'a Config) -> Self {
         Self {
             config,
             mode: None,

--- a/src/page/menu.rs
+++ b/src/page/menu.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use crate::{
     config::{
         Config, ModeConfig, SourceConfig,
-        parameters::{Definition, Parameter},
+        parameters::{Definition, Parameter, ParameterError, ParameterValues},
     },
     page::session::{CreateModeError, FetchError, Mode},
     utils::{center, centered_padding},
@@ -28,6 +28,25 @@ pub enum ContextError {
 
     #[error("No modes where found - You might not have any offline sources available")]
     NoModes,
+
+    #[error("Mode '{name}' not found. Available modes: {available}")]
+    ModeNotFound {
+        name: String,
+        available: String,
+    },
+
+    #[error("Source '{name}' not found for mode '{mode}'. Available sources: {available}")]
+    SourceNotFound {
+        name: String,
+        mode: String,
+        available: String,
+    },
+
+    #[error("Parameter error: {0}")]
+    Parameter(ParameterError),
+
+    #[error("Invalid parameter format '{0}', expected 'name:value'")]
+    InvalidParamFormat(String),
 }
 
 #[derive(Debug, Error, From)]
@@ -101,6 +120,216 @@ impl Menu {
             context: Context::new(config)?,
         })
     }
+
+    /// Creates a new menu pre-selected to a specific mode and starting at source-selection.
+    pub fn new_with_mode(config: &Config, mode_name: &str) -> Result<Self, ContextError> {
+        let mut context = Context::new(config)?;
+
+        let mode_index = context
+            .modes
+            .iter()
+            .position(|m| m.meta.name.eq_ignore_ascii_case(mode_name))
+            .ok_or_else(|| {
+                let available = context
+                    .modes
+                    .iter()
+                    .map(|m| m.meta.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ContextError::ModeNotFound {
+                    name: mode_name.to_string(),
+                    available,
+                }
+            })?;
+
+        let mode = context.modes[mode_index].clone();
+        context.selected_mode = Some(Box::new(mode));
+        context.mode_index = mode_index;
+
+        Ok(Self {
+            state: State::SourceSelect,
+            context,
+        })
+    }
+}
+
+/// Builder for initializing and loading a typing session.
+#[derive(Debug)]
+pub struct SessionBuilder<'a> {
+    config: &'a Config,
+    mode: Option<ModeConfig>,
+    source: Option<SourceConfig>,
+    raw_params: Vec<String>,
+}
+
+impl<'a> SessionBuilder<'a> {
+    pub fn new(config: &'a Config) -> Self {
+        Self {
+            config,
+            mode: None,
+            source: None,
+            raw_params: Vec::new(),
+        }
+    }
+
+    pub fn with_mode_name(mut self, mode_name: &str) -> Result<Self, ContextError> {
+        let modes = self.config.list_modes();
+        if modes.is_empty() {
+            return Err(ContextError::NoModes);
+        }
+
+        let mode = modes
+            .iter()
+            .find(|m| m.meta.name.eq_ignore_ascii_case(mode_name))
+            .cloned()
+            .ok_or_else(|| {
+                let available = modes
+                    .iter()
+                    .map(|m| m.meta.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ContextError::ModeNotFound {
+                    name: mode_name.to_string(),
+                    available,
+                }
+            })?;
+
+        self.mode = Some(mode);
+        Ok(self)
+    }
+
+    pub fn with_source_name(mut self, source_name: &str) -> Result<Self, ContextError> {
+        let sources = self.config.list_sources();
+        if sources.is_empty() {
+            return Err(ContextError::NoSources);
+        }
+
+        let mode_name = self
+            .mode
+            .as_ref()
+            .map(|m| m.meta.name.clone())
+            .unwrap_or_default();
+
+        let source = sources
+            .iter()
+            .find(|s| s.meta.name.eq_ignore_ascii_case(source_name))
+            .cloned()
+            .ok_or_else(|| {
+                let available = sources
+                    .iter()
+                    .map(|s| s.meta.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ContextError::SourceNotFound {
+                    name: source_name.to_string(),
+                    mode: mode_name,
+                    available,
+                }
+            })?;
+
+        self.source = Some(source);
+        Ok(self)
+    }
+
+    #[allow(dead_code)]
+    pub fn with_mode(mut self, mode: ModeConfig) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_source(mut self, source: SourceConfig) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    pub fn with_params(mut self, raw_params: &[String]) -> Self {
+        self.raw_params.extend(raw_params.iter().cloned());
+        self
+    }
+
+    pub fn build_loader(self) -> Result<Loading, ContextError> {
+        let mode = self.mode.ok_or_else(|| ContextError::ModeNotFound {
+            name: String::new(),
+            available: String::new(),
+        })?;
+
+        let source = self.source.ok_or_else(|| ContextError::SourceNotFound {
+            name: String::new(),
+            mode: mode.meta.name.clone(),
+            available: String::new(),
+        })?;
+
+        let source_overrides = mode.overrides.get(&source.meta.name);
+        let mut parameters = Vec::new();
+
+        for (name, definition) in source.parameters.iter().chain(mode.parameters.iter()) {
+            let mut definition = definition.clone();
+            let mut mutable = true;
+            if let Some(overrides) = source_overrides
+                && let Some(override_param) = overrides.get(name)
+            {
+                mutable = false;
+                definition = Definition::FixedString(override_param.clone());
+            }
+
+            let parameter = definition
+                .into_parameter(mutable)
+                .map_err(ContextError::Parameter)?;
+
+            parameters.push((name.clone(), parameter));
+        }
+
+        for raw_param in &self.raw_params {
+            let Some((key, val)) = raw_param.split_once(':') else {
+                return Err(ContextError::InvalidParamFormat(raw_param.clone()));
+            };
+
+            let target = parameters.iter_mut().find(|(name, _)| {
+                name == key
+                    || name.eq_ignore_ascii_case(key)
+                    || name
+                        .split(" (")
+                        .next()
+                        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(key))
+            });
+
+            if let Some((name, param)) = target {
+                param
+                    .set_value_from_str(name, val)
+                    .map_err(ContextError::Parameter)?;
+            } else {
+                return Err(ContextError::Parameter(ParameterError::UnknownParameter(
+                    key.to_string(),
+                )));
+            }
+        }
+
+        let param_values: ParameterValues = parameters.into_iter().collect();
+
+        let session_loader = Loading::load(self.config, "Loading words...", move |config| {
+            let mode = Mode::from_config(config, mode, source, param_values).map_err(Box::new)?;
+            Session::new(config, mode)
+                .map(|session| Message::Show(session.into()))
+                .map_err(CreateSessionError::from)
+        });
+
+        Ok(session_loader)
+    }
+}
+
+/// Creates a loading session page directly from CLI arguments (`--mode`, `--source`, `--param`).
+pub fn create_cli_session(
+    config: &Config,
+    mode_name: &str,
+    source_name: &str,
+    raw_params: &[String],
+) -> Result<Loading, ContextError> {
+    SessionBuilder::new(config)
+        .with_mode_name(mode_name)?
+        .with_source_name(source_name)?
+        .with_params(raw_params)
+        .build_loader()
 }
 
 // Rendering logic

--- a/src/page/menu.rs
+++ b/src/page/menu.rs
@@ -614,7 +614,7 @@ impl ListItem for &ModeConfig {
     }
 
     fn description(&self) -> Option<String> {
-        Some(format!(" - {}", &self.meta.description))
+        Some(format!(" - {}", self.meta.description))
     }
 }
 
@@ -624,7 +624,7 @@ impl ListItem for &SourceConfig {
     }
 
     fn description(&self) -> Option<String> {
-        Some(format!(" - {}", &self.meta.description))
+        Some(format!(" - {}", self.meta.description))
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds command-line arguments (`--mode`, `--source`, `--param`) to allow starting Octotype sessions directly from terminal scripts, desktop shortcuts, or shell commands without requiring manual UI navigation.

Closes #15

---

## Features Added

### 1. Pre-selecting Mode (`--mode` / `-m`)
Passing `--mode <mode_name>` pre-selects the requested mode and opens Octotype directly at the **Source Selection** screen.
```sh
octotype --mode "WordRace"
```

### 2. Instant Session Start (`--mode` + `--source`)
Passing both `--mode <mode_name>` and `--source <source_name>` launches directly into the word loader and typing session:
```sh
octotype --mode "WordRace" --source "brownfox"
```

### 3. Parameter Overrides (`--param` / `-P`)
Passing one or more `--param "<name>:<value>"` options overrides parameters for the selected mode and source combination:
```sh
octotype --mode "WordRace" --source "brownfox" --param "words:50" --param "time (seconds):30"
```

---

## Implementation Details

- **CLI Parsing (`src/main.rs`)**: Extended `AppArgs` struct using `clap`. Enforces strict dependency chains (`--source` requires `--mode`, `--param` requires `--source`).
- **Parameter Mutation & Validation (`src/config/parameters.rs`)**:
  - Implemented `Parameter::set_value_from_str` for in-place mutation with bounds checking for `Range` definitions, case-insensitive string selection, boolean toggle parsing, and fixed parameter locking.
  - Added unit test suite covering range, selection, toggle, and fixed parameter errors.
- **Session Builder Pattern (`src/page/menu.rs`)**:
  - Introduced `SessionBuilder<'a>` to handle mode/source resolution, parameter combination, mode overrides, CLI parameter application, and loader creation.
  - `create_cli_session` uses `SessionBuilder` for clean, fluent session construction.
- **Pre-TUI Error Handling**: Pre-validates flags before initializing `ratatui`. Invalid modes, sources, or parameters output a clean error to `stderr` and exit with status code `1`.
- **Documentation (`README.md`)**: Updated the CLI Arguments reference table with `-m/--mode`, `-s/--source`, and `-P/--param`.

---

## Testing

- Verified `--help` output formatting.
- Added 4 unit tests for parameter parsing in `src/config/parameters.rs`.
- Tested all 7 unit tests with `cargo test` (all passing cleanly).
- Verified invalid argument handling for non-existent modes, non-existent sources, and invalid parameter formats.
